### PR TITLE
Make `make build` need only Go (decouple build from lint)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ TARBALL      := $(RPMBUILD_DIR)/SOURCES/gmt-$(VERSION).tar.gz
 
 .PHONY: all build test vet lint fmt install clean srpm vendor tag release copr ppa
 
-all: test build
+all: test lint build
 
-build: lint
+build:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) .
 
 test:


### PR DESCRIPTION
🤖🤝 Greg — in happy AI+Person collab. Two intelligences, one Makefile target, zero `command not found`. 📬✨

## The bug (a `make build` that doesn't, on a clean machine)

The README's **From source** section advertises exactly one prerequisite:

> Requires [Go](https://go.dev/) 1.24 or later.
> ```
> $ git clone https://github.com/al-maisan/gmt.git
> $ cd gmt
> $ make build
> $ ./gmt-mail -h
> ```

…but `build` depended on `lint`:

```
build → lint → vet → golangci-lint run ./...
```

So `golangci-lint` was a **silent, undocumented prerequisite**. A fresh clone that follows the README to the letter dies at `make build`:

* no linter installed → `golangci-lint: command not found`
* *stale* linter installed → cryptic parser noise, because an old `golangci-lint` can't parse a newer Go stdlib (`expected '(', found '['`, "version skew - reinstall package"). Ask me how I know. 🙃

Building the binary shouldn't require a linter to be present, let alone the *right version* of one.

## The fix

* `build` no longer depends on `lint` — it just compiles. **Go-only.**
* Linting is **not** lost: `all` becomes `test lint build`, so plain `make` still runs the full pre-flight (test → vet → lint → build).
* `make lint` / `make all` still require `golangci-lint`, exactly as before.

```diff
-all: test build
+all: test lint build

-build: lint
+build:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) .
```

Net effect: the documented `make build` now does what the README promises — works on any box with just the Go toolchain. No README change needed; it's simply true now.

## Test plan

* `make build` with **only** Go on `PATH` (no `golangci-lint`) → builds `gmt-mail` cleanly ✅
* `make -n all` → still expands to `go test` → `go vet` → `golangci-lint run` → `go build` ✅
* `gmt-mail` binary remains gitignored; no artifacts added ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)