### PR TITLE
Reject negative -retries and harden sendWithRetry against silent no-op

### DIFF
--- a/email/send.go
+++ b/email/send.go
@@ -195,7 +195,10 @@ func (sc *BatchSender) sendOne(m Message, prefix string) error {
 // with opts.RetryDelay between attempts.
 func (sc *BatchSender) sendWithRetry(msg *mail.Msg, prefix, recipient string) error {
 	var err error
-	for attempt := range sc.opts.Retries + 1 {
+	// Always attempt at least once; a negative Retries must never silently
+	// skip the send and report success.
+	attempts := max(sc.opts.Retries+1, 1)
+	for attempt := range attempts {
 		if attempt > 0 {
 			logf(sc.w, "%s   retrying %s...\n", prefix, recipient)
 			if sc.opts.RetryDelay > 0 {

--- a/email/send_test.go
+++ b/email/send_test.go
@@ -350,6 +350,21 @@ func TestSendAllRetryExhausted(t *testing.T) {
 	assert.Contains(t, buf.String(), "permanent error")
 }
 
+func TestSendAllNegativeRetriesStillSends(t *testing.T) {
+	// A negative Retries must not skip the send and falsely report success.
+	sender := &mockSender{}
+	cfg := config.MailConfig{From: "sender@example.com"}
+	msgs := []Message{
+		{Name: "John", Address: "jd@example.com", Subject: "Hi", Body: "Hello"},
+	}
+
+	var buf bytes.Buffer
+	result := NewBatchSender(&buf, sender, cfg, SendOptions{Retries: -1}).SendAll(msgs)
+	assert.Equal(t, 1, sender.sent)
+	assert.Equal(t, 1, result.Sent)
+	assert.Equal(t, 0, result.Failed)
+}
+
 func TestSendAllWithReplyTo(t *testing.T) {
 	sender := &mockSender{}
 	cfg := config.MailConfig{

--- a/main.go
+++ b/main.go
@@ -97,6 +97,12 @@ func main() {
 	requireFlag(*configPath, "-config-path")
 	requireFlag(*templatePath, "-template-path")
 
+	if *retries < 0 {
+		log.Printf("Error: -retries must be >= 0")
+		flag.Usage()
+		os.Exit(exitUsageError)
+	}
+
 	cfg, err := loadConfig(*configPath)
 	if err != nil {
 		log.Printf("Error: %v", err)


### PR DESCRIPTION
# Reject negative `-retries` and harden `sendWithRetry` against silent no-op

Closes #17

## Problem

`-retries` is read straight from `flag.Int("retries", 1, ...)` with no validation.
`sendWithRetry` iterated `for attempt := range sc.opts.Retries + 1`. A negative
value made the loop bound `<= 0`, so the body ran **zero** times: `Send()` was
never called and the pre-declared `nil` error was returned as success.

Result: `gmt ... -retries=-1` logged every recipient as delivered and printed
`Done: N sent, 0 failed` (exit 0) while transmitting **nothing** — silent data
loss disguised as a successful run.

## Fix

- **`main.go`** — reject `-retries < 0` at the CLI boundary with a usage error
  (`exitUsageError`), before any sending happens.
- **`email/send.go`** — clamp attempts to at least 1
  (`attempts := max(sc.opts.Retries+1, 1)`) so the library can never silently
  skip the send regardless of caller.

Defense in depth: the CLI gives a clear operator-facing error; the library stays
safe even if driven directly from tests or other code.

## Tests

- Added `TestSendAllNegativeRetriesStillSends`: with `Retries: -1`, exactly one
  `Send` occurs and the result reports `1 sent, 0 failed`.
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.

## Scope

Single, focused correctness fix. No behavior change for valid inputs
(`-retries` default 1 and any non-negative value are unaffected).
