### PR TITLE
Fix substitution/validation correctness bugs (#19, #20, #21)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,15 +93,19 @@ func Parse(bs []byte) (MailConfig, error) {
 		return MailConfig{}, err
 	}
 
+	recipients, err := convertRecipients(tc.Recipients)
+	if err != nil {
+		return MailConfig{}, err
+	}
+
 	cfg := MailConfig{
 		From:        tc.General.From,
 		Subject:     tc.General.Subject,
 		ReplyTo:     tc.General.ReplyTo,
 		Cc:          tc.General.Cc,
 		Attachments: tc.General.Attachments,
+		Recipients:  recipients,
 	}
-
-	cfg.Recipients = convertRecipients(tc.Recipients)
 
 	return cfg, nil
 }
@@ -135,14 +139,29 @@ func formatValidationError(err error) error {
 	return fmt.Errorf("%s", strings.Join(msgs, "; "))
 }
 
+// reservedDataKeys are the placeholder keys owned by the template engine
+// (%EA%, %FN%, %LN%). A recipient data key that folds to one of these would be
+// silently shadowed during substitution, so it is rejected at parse time.
+var reservedDataKeys = map[string]struct{}{"EA": {}, "FN": {}, "LN": {}}
+
 // convertRecipients transforms TOML recipient entries into Recipient structs.
-func convertRecipients(entries []tomlRecipient) []Recipient {
-	var recipients []Recipient
+// Data keys are upper-cased to match %KEY% placeholders; it returns an error if
+// two keys collide after folding, or a key collides with a reserved placeholder,
+// since either case would silently drop or nondeterministically pick a value.
+func convertRecipients(entries []tomlRecipient) ([]Recipient, error) {
+	recipients := make([]Recipient, 0, len(entries))
 
 	for _, e := range entries {
 		data := make(map[string]string, len(e.Data))
 		for k, v := range e.Data {
-			data[strings.ToUpper(k)] = v
+			key := strings.ToUpper(k)
+			if _, ok := reservedDataKeys[key]; ok {
+				return nil, fmt.Errorf("recipient %q: data key %q collides with reserved placeholder %%%s%%", e.Email, k, key)
+			}
+			if _, ok := data[key]; ok {
+				return nil, fmt.Errorf("recipient %q: data keys collide after upper-casing to %q", e.Email, key)
+			}
+			data[key] = v
 		}
 
 		recipients = append(recipients, Recipient{
@@ -156,7 +175,7 @@ func convertRecipients(entries []tomlRecipient) []Recipient {
 			AttachmentsExtra: e.AttachmentsExtra,
 		})
 	}
-	return recipients
+	return recipients, nil
 }
 
 // checkAttachments verifies that every path in attachments exists and is accessible.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -268,6 +268,34 @@ data = { org = "EFF" }
 	assert.Equal(t, "EFF", cfg.Recipients[0].Data["ORG"])
 }
 
+func TestParseDataKeyCaseCollision(t *testing.T) {
+	_, err := Parse([]byte(`
+[general]
+from = "test <t@example.com>"
+subject = "test"
+[[recipients]]
+email = "a@b.com"
+first = "A"
+data = { url = "a", URL = "b" }
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collide after upper-casing")
+}
+
+func TestParseDataKeyReservedCollision(t *testing.T) {
+	_, err := Parse([]byte(`
+[general]
+from = "test <t@example.com>"
+subject = "test"
+[[recipients]]
+email = "a@b.com"
+first = "A"
+data = { fn = "Company" }
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved placeholder %FN%")
+}
+
 func TestCheckAttachmentsValid(t *testing.T) {
 	tmpFile := t.TempDir() + "/test.txt"
 	require.NoError(t, os.WriteFile(tmpFile, []byte("content"), 0o644))

--- a/config/samples/config.toml
+++ b/config/samples/config.toml
@@ -29,12 +29,13 @@ data = { ORG = "NASA", TITLE = "Dr." }
 cc_extra = ["inc@gg.org"]
 
 # The 'attachments' field below *replaces* the global 'attachments' value above
+# (uncomment and point at real files; missing attachments fail -validate)
 [[recipients]]
 email = "ab@example.com"
 first = "Alice"
 last = "Brown"
 data = { ORG = "MIT" }
-attachments = ["file1.txt", "file2.md"]
+# attachments = ["file1.txt", "file2.md"]
 
 [[recipients]]
 email = "mm@gmail.com"
@@ -43,9 +44,10 @@ last = "Mouse"
 data = { ORG = "Disney" }
 
 # The 'attachments_extra' field below *appends* to the global 'attachments' value above
+# (uncomment and point at real files; missing attachments fail -validate)
 [[recipients]]
 email = "ef@example.com"
 first = "Eve"
 last = "Foster"
 data = { ORG = "CERN", TITLE = "Prof." }
-attachments_extra = ["file3.pdf"]
+# attachments_extra = ["file3.pdf"]

--- a/email/prep.go
+++ b/email/prep.go
@@ -61,6 +61,42 @@ func substituteVariables(recipient config.Recipient, text string) string {
 	return strings.NewReplacer(pairs...).Replace(text)
 }
 
+// placeholderKey returns the KEY inside a "%KEY%" placeholder constant.
+func placeholderKey(p string) string { return p[1 : len(p)-1] }
+
+// availableKeys returns the set of placeholder keys resolvable for a recipient:
+// the reserved keys (EA/FN/LN) plus the recipient's upper-cased data keys.
+func availableKeys(r config.Recipient) map[string]struct{} {
+	keys := make(map[string]struct{}, len(r.Data)+3)
+	keys[placeholderKey(placeholderEmail)] = struct{}{}
+	keys[placeholderKey(placeholderFirstName)] = struct{}{}
+	keys[placeholderKey(placeholderLastName)] = struct{}{}
+	for k := range r.Data {
+		keys[k] = struct{}{}
+	}
+	return keys
+}
+
+// unresolvedPlaceholders returns the distinct %KEY% tokens in the ORIGINAL
+// (pre-substitution) text whose KEY is not resolvable. Scanning the original
+// text rather than the substituted result avoids misreporting substituted
+// values that merely look like placeholders (e.g. a data value "50%OFF%deal").
+func unresolvedPlaceholders(text string, keys map[string]struct{}) []string {
+	var missing []string
+	seen := make(map[string]struct{})
+	for _, m := range rePlaceholder.FindAllString(text, -1) {
+		if _, ok := keys[placeholderKey(m)]; ok {
+			continue
+		}
+		if _, dup := seen[m]; dup {
+			continue
+		}
+		seen[m] = struct{}{}
+		missing = append(missing, m)
+	}
+	return missing
+}
+
 // PrepMails generates a Message for each recipient by substituting template
 // variables and resolving per-recipient Cc and attachment overrides.
 // Returns an error if any placeholders remain unresolved.
@@ -71,15 +107,16 @@ func PrepMails(cfg *config.MailConfig, template string) ([]Message, error) {
 		cc := resolveOverride(cfg.Cc, recipient.Cc, recipient.CcExtra)
 		attachments := resolveOverride(cfg.Attachments, recipient.Attachments, recipient.AttachmentsExtra)
 
-		subject := substituteVariables(recipient, cfg.Subject)
-		body := substituteVariables(recipient, template)
-
-		if unresolved := rePlaceholder.FindAllString(subject, -1); len(unresolved) > 0 {
+		keys := availableKeys(recipient)
+		if unresolved := unresolvedPlaceholders(cfg.Subject, keys); len(unresolved) > 0 {
 			errs = append(errs, fmt.Sprintf("recipient '%s': unresolved placeholder(s) in subject: %s", recipient.Email, strings.Join(unresolved, ", ")))
 		}
-		if unresolved := rePlaceholder.FindAllString(body, -1); len(unresolved) > 0 {
+		if unresolved := unresolvedPlaceholders(template, keys); len(unresolved) > 0 {
 			errs = append(errs, fmt.Sprintf("recipient '%s': unresolved placeholder(s) in body: %s", recipient.Email, strings.Join(unresolved, ", ")))
 		}
+
+		subject := substituteVariables(recipient, cfg.Subject)
+		body := substituteVariables(recipient, template)
 
 		name := strings.TrimSpace(recipient.First + " " + recipient.Last)
 		mails = append(mails, Message{

--- a/email/prep_test.go
+++ b/email/prep_test.go
@@ -181,6 +181,21 @@ func TestPrepMailsNoErrorWhenAllResolved(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestPrepMailsPlaceholderLikeValueNotFlagged(t *testing.T) {
+	// A substituted value that merely looks like a placeholder must not be
+	// misreported as unresolved (regression: batch abort on "50%OFF%deal").
+	cfg := config.MailConfig{
+		Subject: "Deal for %FN%",
+		Recipients: []config.Recipient{
+			{Email: "a@b.com", First: "Alice", Last: "Bob", Data: map[string]string{"PROMO": "50%OFF%deal"}},
+		},
+	}
+	mails, err := PrepMails(&cfg, "Hello %FN%, code: %PROMO%")
+	require.NoError(t, err)
+	require.Len(t, mails, 1)
+	assert.Equal(t, "Hello Alice, code: 50%OFF%deal", mails[0].Body)
+}
+
 func TestResolveOverride(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/email/send.go
+++ b/email/send.go
@@ -110,6 +110,20 @@ func NewSMTPSender(creds SMTPCredentials) (Sender, error) {
 	return &smtpSender{client: client}, nil
 }
 
+// CheckAttachments verifies that every resolved attachment across all messages
+// exists and is accessible, so missing files (including per-recipient overrides)
+// are reported up front — e.g. during -validate — instead of only mid-send.
+func CheckAttachments(msgs []Message) error {
+	for _, m := range msgs {
+		for _, path := range m.Attachments {
+			if _, err := os.Stat(path); err != nil {
+				return fmt.Errorf("attachment %q for recipient %s: %w", path, m.Address, err)
+			}
+		}
+	}
+	return nil
+}
+
 // BatchSender holds the per-batch state for delivering a set of messages.
 type BatchSender struct {
 	w       io.Writer

--- a/email/send_test.go
+++ b/email/send_test.go
@@ -350,6 +350,25 @@ func TestSendAllRetryExhausted(t *testing.T) {
 	assert.Contains(t, buf.String(), "permanent error")
 }
 
+func TestCheckAttachments(t *testing.T) {
+	existing := t.TempDir() + "/present.txt"
+	require.NoError(t, os.WriteFile(existing, []byte("x"), 0o644))
+
+	// Existing per-recipient attachment: no error.
+	assert.NoError(t, CheckAttachments([]Message{
+		{Address: "a@b.com", Attachments: []string{existing}},
+	}))
+
+	// Missing per-recipient attachment: reported up front with recipient context.
+	err := CheckAttachments([]Message{
+		{Address: "a@b.com", Attachments: []string{existing}},
+		{Address: "c@d.com", Attachments: []string{"/nonexistent/missing.pdf"}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "/nonexistent/missing.pdf")
+	assert.Contains(t, err.Error(), "c@d.com")
+}
+
 func TestSendAllNegativeRetriesStillSends(t *testing.T) {
 	// A negative Retries must not skip the send and falsely report success.
 	sender := &mockSender{}

--- a/main.go
+++ b/main.go
@@ -115,6 +115,11 @@ func main() {
 		os.Exit(exitConfigError)
 	}
 
+	if err := email.CheckAttachments(msgs); err != nil {
+		log.Printf("Error: %v", err)
+		os.Exit(exitConfigError)
+	}
+
 	if *doValidate {
 		fmt.Printf("Config and template are valid: %d recipient(s)\n", len(msgs))
 		os.Exit(exitOK)


### PR DESCRIPTION
# Fix substitution/validation correctness bugs (data-key collisions, placeholder false-positives, attachment validation)

Closes #19, #20, #21

Three correctness fixes surfaced by an adversarial review. All are trust-model
independent (they bite an operator using their own valid config). No functional
change for well-formed input.

## #19 — False "unresolved placeholder" aborts the whole batch (HIGH)

`email/prep.go` scanned the **substituted** subject/body with
`%[A-Z][A-Z0-9_]*%`, so a legitimate value that merely looked like a token
(`data = { PROMO = "50%OFF%deal" }`) was reported as unresolved — and because
`PrepMails` fails if *any* recipient matches, one bad value blocked delivery to
everyone (also breaking `-validate`/`-dry-run`).

Fix: check placeholders in the **original** template/subject against the set of
resolvable keys (`EA/FN/LN` + the recipient's data keys), never the substituted
text. Genuine typos are still caught; look-alike values no longer false-trip.

## #20 — Recipient data-key collisions silently drop/scramble values (MEDIUM)

`config/config.go` folded data keys to uppercase (`data[strings.ToUpper(k)]`)
with no collision guard: `{ url = "a", URL = "b" }` produced a
map-iteration-order-dependent (nondeterministic) winner, and a data key
`EA`/`FN`/`LN` was silently shadowed by the reserved placeholders.

Fix: `convertRecipients` now returns an error when two keys collide after
upper-casing, or a key collides with a reserved placeholder.

## #21 — `-validate` missed missing per-recipient attachments (LOW)

Only `general.attachments` was existence-checked at parse; per-recipient
`attachments`/`attachments_extra` failed only mid-send. Added
`email.CheckAttachments`, invoked in `main` right after prep, so missing files
(including per-recipient overrides) fail fast — for `-validate`, `-dry-run`, and
real sends alike. The shipped sample's example attachment lines are commented
out (like the general ones) so the documented quick-start still validates clean.

## Tests

- `TestPrepMailsPlaceholderLikeValueNotFlagged` — `%OFF%`-shaped value passes.
- `TestParseDataKeyCaseCollision`, `TestParseDataKeyReservedCollision`.
- `TestCheckAttachments` — present ok, missing reported with recipient context.
- `go build`, `go vet`, `go test ./...`, `gosec` (no new issues) all clean.

## Not addressed (deliberately)

Two adversarial findings were verified as **documented behavior under gmt's
single-operator trust model**, not vulnerabilities, and are intentionally left
as-is: unrestricted attachment paths (the sample ships absolute/`../` paths) and
`.env` auto-load from the working directory. Both would require breaking
documented features to "harden"; revisit only if untrusted config ingestion
becomes a use case.
