### PR TITLE
Derive VERSION from the git tag; drop the manual bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 BINARY  := gmt-mail
-VERSION := 0.6.2
+# VERSION is derived from the latest git tag (the single source of truth for a
+# release). Cut a release by creating the tag, e.g.:
+#   git tag -s v0.7.0 -m "v0.7.0" && git push origin v0.7.0
+# Override for a one-shot cut before the tag exists: make release VERSION=0.7.0
+GIT_VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null)
+VERSION     := $(patsubst v%,%,$(or $(GIT_VERSION),v0.0.0))
 COMMIT  := $(shell git rev-parse --short HEAD)
 DATE    := $(shell date -u +%Y-%m-%d)
 LDFLAGS := -X main.appVersion=$(VERSION) -X main.gitCommit=$(COMMIT) -X main.buildDate=$(DATE)

--- a/README.md
+++ b/README.md
@@ -191,11 +191,14 @@ Transient send failures are retried automatically (controlled by `-retries` and 
 
 ## Releasing a new version
 
-Update `VERSION` in the Makefile, commit, then publish everywhere:
+The version is derived from the latest git tag — there is no `VERSION` to edit.
+Cut a release by creating and pushing a signed tag, then publish everywhere:
 
+    $ git tag -s v0.7.0 -m "v0.7.0"
+    $ git push origin v0.7.0
     $ make publish
 
-This tags the release, creates a GitHub release, submits to Fedora COPR, and uploads to Ubuntu PPA.
+`make publish` creates the GitHub release, submits to Fedora COPR, and uploads to Ubuntu PPA, all using the tagged version. To cut it in one shot without tagging first, override: `make publish VERSION=0.7.0` creates and pushes the tag for you.
 
 Individual targets are also available:
 


### PR DESCRIPTION
# Derive VERSION from the git tag; drop the manual bump

Make the git tag the single source of truth for the release version, removing
the hand-edited `VERSION := x.y.z` (and the accompanying "new release" commit).

## Change

`Makefile`:
```make
GIT_VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null)
VERSION     := $(patsubst v%,%,$(or $(GIT_VERSION),v0.0.0))
```
`--abbrev=0` yields a bare `0.7.0` (valid for RPM/PPA and the embedded
`appVersion`); `TAG := v$(VERSION)` and everything downstream follow unchanged.
Command-line override still works (`make ... VERSION=0.7.0`) since CLI
assignments win over Makefile ones.

## New release flow

    git tag -s v0.7.0 -m "v0.7.0"
    git push origin v0.7.0
    make publish

Or one-shot (creates+pushes the tag via the `tag` prereq):

    make publish VERSION=0.7.0

## Verified

- `make build` → `appVersion=0.6.2` (latest tag); `make build VERSION=0.7.0` →
  `0.7.0`. Binary `-version` confirms both.
- `make -n tag` expands `git tag -s v0.6.2`; with override, `v0.7.0`.
- README "Releasing a new version" updated to the tag-first flow.
