### PR TITLE
ppa: derive version from git tag, not Makefile scrape

### DIFF
--- a/ppa/build-ppa.sh
+++ b/ppa/build-ppa.sh
@@ -11,9 +11,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SRC_DIR="$(dirname "$SCRIPT_DIR")"
 BUILD_DIR="/tmp/gmt-ppa-build"
 
-# Read version from Makefile
-VERSION=$(grep '^VERSION' "$SRC_DIR/Makefile" | head -1 | awk -F':= ' '{print $2}' | tr -d ' ')
-TAG="v${VERSION}"
+# Derive version from the latest git tag (the single source of truth)
+TAG=$(git -C "$SRC_DIR" describe --tags --abbrev=0)
+VERSION="${TAG#v}"
 
 # Ubuntu releases to target (add/remove as needed)
 RELEASES=("resolute")  # 26.04 LTS


### PR DESCRIPTION
# ppa: derive version from git tag, not Makefile scrape

Follow-up fix to #23. After VERSION became a `git describe` expression in the
Makefile, `ppa/build-ppa.sh` — which scraped it textually
(`grep '^VERSION' Makefile | awk -F':= '`) — read the raw make expression and
`make ppa` failed with:

    Error: git tag 'v$(patsubstv%,%,$(or$(GIT_VERSION),v0.0.0))' not found.

## Fix

`ppa/build-ppa.sh` now derives the version from the latest git tag, matching the
Makefile and working standalone (`ppa/build-ppa.sh 2`):

```sh
TAG=$(git -C "$SRC_DIR" describe --tags --abbrev=0)
VERSION="${TAG#v}"
```

## Verified

- `git describe --tags --abbrev=0` → `v0.7.0`; `VERSION=0.7.0`, `TAG=v0.7.0`.
- `bash -n ppa/build-ppa.sh` clean.
- No other script scrapes VERSION from the Makefile (`srpm`/`copr` get
  `$(VERSION)` from make directly, so they were unaffected).
