### PR TITLE
Fix send-path robustness & CLI/config correctness bugs (#25–#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Use `-dry-run` to preview all emails without sending. The output includes Cc and
             output sample template to stdout
       -template-path string
             path to the template file
+      -timeout duration
+            SMTP connect/send timeout (covers the full attachment upload) (default 30s)
       -validate
             validate config and template without sending
       -version

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,6 @@ package config
 import (
 	_ "embed"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -89,8 +88,8 @@ func Parse(bs []byte) (MailConfig, error) {
 		return MailConfig{}, formatValidationError(err)
 	}
 
-	if err := checkAttachments(tc.General.Attachments); err != nil {
-		return MailConfig{}, err
+	if strings.TrimSpace(tc.General.Subject) == "" {
+		return MailConfig{}, fmt.Errorf("subject must not be empty or whitespace")
 	}
 
 	recipients, err := convertRecipients(tc.Recipients)
@@ -176,19 +175,6 @@ func convertRecipients(entries []tomlRecipient) ([]Recipient, error) {
 		})
 	}
 	return recipients, nil
-}
-
-// checkAttachments verifies that every path in attachments exists and is accessible.
-func checkAttachments(attachments []string) error {
-	for _, path := range attachments {
-		if _, err := os.Stat(path); err != nil {
-			if os.IsNotExist(err) {
-				return fmt.Errorf("attachment not found: %s", path)
-			}
-			return fmt.Errorf("attachment not accessible: %s: %w", path, err)
-		}
-	}
-	return nil
 }
 
 //go:embed samples/config.toml

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -296,34 +296,6 @@ data = { fn = "Company" }
 	assert.Contains(t, err.Error(), "reserved placeholder %FN%")
 }
 
-func TestCheckAttachmentsValid(t *testing.T) {
-	tmpFile := t.TempDir() + "/test.txt"
-	require.NoError(t, os.WriteFile(tmpFile, []byte("content"), 0o644))
-	assert.NoError(t, checkAttachments([]string{tmpFile}))
-}
-
-func TestCheckAttachmentsEmpty(t *testing.T) {
-	assert.NoError(t, checkAttachments(nil))
-}
-
-func TestCheckAttachmentsMissing(t *testing.T) {
-	err := checkAttachments([]string{"/nonexistent/file.txt"})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "attachment not found")
-}
-
-func TestCheckAttachmentsNotAccessible(t *testing.T) {
-	dir := t.TempDir()
-	path := dir + "/noperm.txt"
-	require.NoError(t, os.WriteFile(path, []byte("x"), 0o644))
-	require.NoError(t, os.Chmod(path, 0o000))
-	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
-
-	// On most systems os.Stat succeeds even without read permission,
-	// so this test just verifies the function doesn't panic.
-	_ = checkAttachments([]string{path})
-}
-
 func TestParseWithAttachments(t *testing.T) {
 	tmpFile := t.TempDir() + "/attach.txt"
 	require.NoError(t, os.WriteFile(tmpFile, []byte("x"), 0o644))
@@ -340,18 +312,17 @@ first = "Alice"
 	assert.Equal(t, []string{tmpFile}, cfg.Attachments)
 }
 
-func TestParseWithMissingAttachment(t *testing.T) {
+func TestParseWhitespaceSubject(t *testing.T) {
 	_, err := Parse([]byte(`
 [general]
 from = "a <a@a.com>"
-subject = "test"
-attachments = ["/nonexistent/file.txt"]
+subject = "   "
 [[recipients]]
 email = "a@b.com"
 first = "Alice"
 `))
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "attachment not found")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subject must not be empty")
 }
 
 func TestSampleConfigParses(t *testing.T) {

--- a/email/send.go
+++ b/email/send.go
@@ -18,6 +18,7 @@ package email
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -32,6 +33,8 @@ import (
 // Sender abstracts the ability to send an email message.
 type Sender interface {
 	Send(msg *mail.Msg) error
+	// Reconnect re-establishes the underlying connection after it has dropped.
+	Reconnect() error
 	Close() error
 }
 
@@ -90,15 +93,22 @@ func LoadSMTPCredentials() (SMTPCredentials, error) {
 }
 
 // NewSMTPSender creates a connected SMTP sender using the given credentials.
-// The caller must call Close when done.
-func NewSMTPSender(creds SMTPCredentials) (Sender, error) {
-	client, err := mail.NewClient(creds.Host,
+// A positive timeout bounds each connect and per-message send (covering the
+// full DATA/attachment stream); zero uses the go-mail default. The caller must
+// call Close when done.
+func NewSMTPSender(creds SMTPCredentials, timeout time.Duration) (Sender, error) {
+	opts := []mail.Option{
 		mail.WithPort(creds.Port),
 		mail.WithUsername(creds.User),
 		mail.WithPassword(creds.Password),
 		mail.WithSMTPAuth(mail.SMTPAuthPlain),
 		mail.WithTLSPolicy(mail.TLSMandatory),
-	)
+	}
+	if timeout > 0 {
+		opts = append(opts, mail.WithTimeout(timeout))
+	}
+
+	client, err := mail.NewClient(creds.Host, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SMTP client for %s:%d: %w", creds.Host, creds.Port, err)
 	}
@@ -176,6 +186,13 @@ type smtpSender struct {
 func (s *smtpSender) Send(msg *mail.Msg) error { return s.client.Send(msg) }
 func (s *smtpSender) Close() error             { return s.client.Close() }
 
+// Reconnect closes the (likely dead) connection best-effort and re-dials,
+// reusing the client's stored configuration.
+func (s *smtpSender) Reconnect() error {
+	_ = s.client.Close()
+	return s.client.DialWithContext(context.Background())
+}
+
 // sendOne prepares and sends a single message, with retries.
 func (sc *BatchSender) sendOne(m Message, prefix string) error {
 	recipient := fmt.Sprintf("%s <%s>", m.Name, m.Address)
@@ -205,8 +222,11 @@ func (sc *BatchSender) sendOne(m Message, prefix string) error {
 	return nil
 }
 
-// sendWithRetry attempts to send msg, retrying up to opts.Retries times
-// with opts.RetryDelay between attempts.
+// sendWithRetry attempts to send msg, retrying up to opts.Retries times with
+// opts.RetryDelay between attempts. When a failure looks like a dropped
+// connection it re-dials before the next attempt, so a server that closes the
+// connection mid-batch (idle timeout, per-connection message cap) does not doom
+// every remaining recipient.
 func (sc *BatchSender) sendWithRetry(msg *mail.Msg, prefix, recipient string) error {
 	var err error
 	// Always attempt at least once; a negative Retries must never silently
@@ -215,6 +235,11 @@ func (sc *BatchSender) sendWithRetry(msg *mail.Msg, prefix, recipient string) er
 	for attempt := range attempts {
 		if attempt > 0 {
 			logf(sc.w, "%s   retrying %s...\n", prefix, recipient)
+			if isConnectionError(err) {
+				if rcErr := sc.sender.Reconnect(); rcErr != nil {
+					logf(sc.w, "%s   reconnect failed: %v\n", prefix, rcErr)
+				}
+			}
 			if sc.opts.RetryDelay > 0 {
 				time.Sleep(sc.opts.RetryDelay)
 			}
@@ -223,9 +248,34 @@ func (sc *BatchSender) sendWithRetry(msg *mail.Msg, prefix, recipient string) er
 		if err == nil {
 			return nil
 		}
+		// The server accepted the message but a later step (e.g. RSET) failed:
+		// it was delivered, so do not count it as failed or re-send it.
+		if deliveredDespiteError(msg, err) {
+			return nil
+		}
 	}
 	logf(sc.w, "%s ! %s (failed to send: %v)\n", prefix, recipient, err)
 	return err
+}
+
+// isConnectionError reports whether err indicates the SMTP connection is dead
+// or temporarily unusable, so a reconnect should precede the next attempt.
+func isConnectionError(err error) bool {
+	var se *mail.SendError
+	if errors.As(err, &se) {
+		return se.Reason == mail.ErrConnCheck || se.IsTemp()
+	}
+	return false
+}
+
+// deliveredDespiteError reports whether the server actually accepted msg even
+// though Send returned an error (e.g. a post-delivery RSET failure).
+func deliveredDespiteError(msg *mail.Msg, err error) bool {
+	if msg.IsDelivered() {
+		return true
+	}
+	var se *mail.SendError
+	return errors.As(err, &se) && se.Reason == mail.ErrSMTPReset
 }
 
 // createMessage builds a single email message with the given headers and body.

--- a/email/send_test.go
+++ b/email/send_test.go
@@ -187,6 +187,8 @@ func (m *mockSender) Send(_ *mail.Msg) error {
 	return nil
 }
 
+func (m *mockSender) Reconnect() error { return nil }
+
 func (m *mockSender) Close() error {
 	m.closed = true
 	return nil
@@ -199,7 +201,7 @@ func TestNewSMTPSenderConnectionError(t *testing.T) {
 		User:     "user",
 		Password: "pass",
 	}
-	_, err := NewSMTPSender(creds)
+	_, err := NewSMTPSender(creds, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to connect")
 }
@@ -316,6 +318,8 @@ func (f *failNthSender) Send(_ *mail.Msg) error {
 	return nil
 }
 
+func (f *failNthSender) Reconnect() error { return nil }
+
 func (f *failNthSender) Close() error { return nil }
 
 func TestSendAllRetrySuccess(t *testing.T) {
@@ -367,6 +371,59 @@ func TestCheckAttachments(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "/nonexistent/missing.pdf")
 	assert.Contains(t, err.Error(), "c@d.com")
+}
+
+// connDropSender fails the first send with a dropped-connection error, then
+// succeeds; it records how many times Reconnect was invoked.
+type connDropSender struct {
+	sends   int
+	reconns int
+}
+
+func (c *connDropSender) Send(_ *mail.Msg) error {
+	c.sends++
+	if c.sends == 1 {
+		return &mail.SendError{Reason: mail.ErrConnCheck}
+	}
+	return nil
+}
+func (c *connDropSender) Reconnect() error { c.reconns++; return nil }
+func (c *connDropSender) Close() error     { return nil }
+
+func TestSendAllReconnectsOnDroppedConnection(t *testing.T) {
+	sender := &connDropSender{}
+	cfg := config.MailConfig{From: "sender@example.com"}
+	msgs := []Message{{Name: "John", Address: "jd@example.com", Subject: "Hi", Body: "Hello"}}
+
+	var buf bytes.Buffer
+	result := NewBatchSender(&buf, sender, cfg, SendOptions{Retries: 1}).SendAll(msgs)
+	assert.Equal(t, 1, result.Sent)
+	assert.Equal(t, 0, result.Failed)
+	assert.Equal(t, 1, sender.reconns, "should re-dial after a dropped connection")
+	assert.Equal(t, 2, sender.sends)
+}
+
+// resetErrSender always returns a post-delivery RSET error — the server has
+// already accepted the message.
+type resetErrSender struct{ sends int }
+
+func (r *resetErrSender) Send(_ *mail.Msg) error {
+	r.sends++
+	return &mail.SendError{Reason: mail.ErrSMTPReset}
+}
+func (r *resetErrSender) Reconnect() error { return nil }
+func (r *resetErrSender) Close() error     { return nil }
+
+func TestSendAllDeliveredDespiteResetError(t *testing.T) {
+	sender := &resetErrSender{}
+	cfg := config.MailConfig{From: "sender@example.com"}
+	msgs := []Message{{Name: "John", Address: "jd@example.com", Subject: "Hi", Body: "Hello"}}
+
+	var buf bytes.Buffer
+	result := NewBatchSender(&buf, sender, cfg, SendOptions{Retries: 2}).SendAll(msgs)
+	assert.Equal(t, 1, result.Sent, "delivered message must count as sent, not failed")
+	assert.Equal(t, 0, result.Failed)
+	assert.Equal(t, 1, sender.sends, "must not retry an already-delivered message")
 }
 
 func TestSendAllNegativeRetriesStillSends(t *testing.T) {

--- a/gmt-mail.1
+++ b/gmt-mail.1
@@ -79,6 +79,11 @@ Backoff duration between retries (e.g.,
 .IR 5s ).
 Default is 2s.
 .TP
+.BI \-timeout " duration"
+SMTP connection and per-message send timeout, covering the full DATA and
+attachment upload. Raise it for large attachments over slow links. Default is
+30s.
+.TP
 .B \-sample\-config
 Print a sample configuration file to standard output and exit.
 .TP

--- a/main.go
+++ b/main.go
@@ -78,8 +78,13 @@ func main() {
 	delay := flag.Duration("delay", 0, "delay between emails (e.g., 1s, 500ms)")
 	retries := flag.Int("retries", 1, "max retry attempts per failed send")
 	retryDelay := flag.Duration("retry-delay", 2*time.Second, "backoff between retries")
+	timeout := flag.Duration("timeout", 30*time.Second, "SMTP connect/send timeout (covers the full attachment upload)")
 
 	flag.Parse()
+
+	if actionFlagCount(*doVersion, *doSampleConfig, *doSampleTemplate, *doValidate, *doDryRun) > 1 {
+		log.Printf("Warning: multiple action flags set; only the first in precedence order takes effect")
+	}
 
 	if *doVersion {
 		fmt.Println(version())
@@ -99,6 +104,11 @@ func main() {
 
 	if *retries < 0 {
 		log.Printf("Error: -retries must be >= 0")
+		flag.Usage()
+		os.Exit(exitUsageError)
+	}
+	if *delay < 0 || *retryDelay < 0 || *timeout < 0 {
+		log.Printf("Error: -delay, -retry-delay and -timeout must be >= 0")
 		flag.Usage()
 		os.Exit(exitUsageError)
 	}
@@ -136,16 +146,11 @@ func main() {
 		os.Exit(exitSMTPError)
 	}
 
-	sender, err := email.NewSMTPSender(creds)
+	sender, err := email.NewSMTPSender(creds, *timeout)
 	if err != nil {
 		log.Printf("SMTP error: %v", err)
 		os.Exit(exitSMTPError)
 	}
-	defer func() {
-		if err := sender.Close(); err != nil {
-			log.Printf("Warning: failed to close SMTP connection: %v", err)
-		}
-	}()
 
 	opts := email.SendOptions{
 		Delay:      *delay,
@@ -155,11 +160,29 @@ func main() {
 	batch := email.NewBatchSender(os.Stdout, sender, cfg, opts)
 	fmt.Println("\nSending emails now..")
 	result := batch.SendAll(msgs)
+
+	// Close explicitly (not via defer) so the graceful SMTP QUIT runs even on
+	// the exitSendFailure path below — os.Exit does not run deferred calls.
+	if cerr := sender.Close(); cerr != nil {
+		log.Printf("Warning: failed to close SMTP connection: %v", cerr)
+	}
+
 	fmt.Printf("\nDone: %d sent, %d failed, %d total\n", result.Sent, result.Failed, result.Sent+result.Failed)
 
 	if result.Failed > 0 {
 		os.Exit(exitSendFailure)
 	}
+}
+
+// actionFlagCount returns how many mutually-exclusive action flags are set.
+func actionFlagCount(flags ...bool) int {
+	n := 0
+	for _, f := range flags {
+		if f {
+			n++
+		}
+	}
+	return n
 }
 
 func loadConfig(path string) (config.MailConfig, error) {
@@ -180,6 +203,9 @@ func prepMails(cfg *config.MailConfig, templatePath string) ([]email.Message, er
 	bs, err := os.ReadFile(templatePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read template file %q: %w", templatePath, err)
+	}
+	if len(strings.TrimSpace(string(bs))) == 0 {
+		return nil, fmt.Errorf("template file %q is empty", templatePath)
 	}
 
 	msgs, err := email.PrepMails(cfg, string(bs))


### PR DESCRIPTION
# Send-path robustness & CLI/config correctness fixes

Closes #25, #26, #27, #28, #29, #30, #31

Fixes the batch of bugs found by the lifecycle + CLI-semantics audit. Grouped
into one PR because they overlap in `main.go`/`email/send.go`. All existing
behavior for well-formed input is unchanged.

## #25 (HIGH) — reconnect after a dropped connection
`Sender` gains `Reconnect()`; `sendWithRetry` re-dials before the next attempt
when a failure looks like a dead/temporary connection (`SendError` with
`ErrConnCheck` or `IsTemp()`). Previously a server that closed the connection
mid-batch (idle timeout / per-connection message cap) doomed every remaining
recipient, since retries hit the same dead client. `smtpSender.Reconnect`
closes best-effort and calls `DialWithContext` again (reuses stored config).

## #26 (MED) — delivered message no longer counted as failed / re-sent
`deliveredDespiteError` treats a message as sent when the server accepted it but
a later step failed (`Msg.IsDelivered()`, or `SendError.Reason == ErrSMTPReset`).
Previously a post-DATA RSET failure marked a delivered recipient as failed
(wrong exit 4) and retried it — a potential duplicate delivery.

## #27 (LOW) — graceful QUIT on the failure path
`main` now `Close()`s the sender explicitly before the `os.Exit(exitSendFailure)`
(removed the `defer`, which `os.Exit` skips). Graceful SMTP QUIT now runs whether
or not any recipient failed.

## #28 (LOW–MED) — configurable timeout for large attachments
New `-timeout` flag (default 30s, up from go-mail's 15s) passed via
`mail.WithTimeout`, so a multi-MB attachment on a slow link doesn't blow the
single per-message deadline. Documented in the man page and README.

## #29 (LOW) — reject semantically-empty content
Whitespace-only `subject` is rejected at parse (`required` only caught the empty
string); an empty/whitespace-only template file is rejected in `prepMails`.
No more silently-blank subjects/bodies passing `-validate`.

## #30 (LOW) — no false-positive on overridden global attachments
Dropped the parse-time `checkAttachments(general)`; `email.CheckAttachments`
(run after prep) already validates the *resolved* per-recipient paths. A config
whose `[general] attachments` is missing but overridden by every recipient no
longer errors. Removes duplicate stat logic.

## #31 (LOW) — consistent bad-value flag handling
Negative `-delay`/`-retry-delay`/`-timeout` are now rejected like `-retries`
(usage error). A warning is printed when multiple mutually-exclusive action
flags are combined.

## Tests
- `TestSendAllReconnectsOnDroppedConnection`, `TestSendAllDeliveredDespiteResetError`
- `TestParseWhitespaceSubject`; removed the now-obsolete config-level
  `checkAttachments`/parse-missing-attachment tests (behavior moved to
  `email.CheckAttachments`).
- `go build`, `go vet`, `go test ./...`, `gosec` (no new issues) all clean.
