### PR TITLE
Run gh without ambient GITHUB_TOKEN in release/packaging targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ DATE    := $(shell date -u +%Y-%m-%d)
 LDFLAGS := -X main.appVersion=$(VERSION) -X main.gitCommit=$(COMMIT) -X main.buildDate=$(DATE)
 TAG     := v$(VERSION)
 
+# Run gh with any ambient GITHUB_TOKEN removed so it uses the keyring login;
+# a narrow-scoped GITHUB_TOKEN in the environment cannot create releases.
+GH := env -u GITHUB_TOKEN gh
+
 RPMBUILD_DIR := /tmp/gmt-rpmbuild
 TARBALL      := $(RPMBUILD_DIR)/SOURCES/gmt-$(VERSION).tar.gz
 SPEC_TEMPLATE := gmt-mail.spec
@@ -54,17 +58,17 @@ tag:
 		echo "tag: pushed $(TAG)"; \
 	fi
 
-PREV_RELEASE := $(shell gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null)
+PREV_RELEASE := $(shell $(GH) release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null)
 
 release: tag
-	@if gh release view $(TAG) >/dev/null 2>&1; then \
+	@if $(GH) release view $(TAG) >/dev/null 2>&1; then \
 		echo "release: $(TAG) exists on GitHub"; \
 	elif [ -n "$(PREV_RELEASE)" ]; then \
-		gh release create $(TAG) --title "$(TAG)" --generate-notes --notes-start-tag $(PREV_RELEASE); \
-		echo "release: created $(TAG) (diff from $(PREV_RELEASE))"; \
+		$(GH) release create $(TAG) --title "$(TAG)" --generate-notes --notes-start-tag $(PREV_RELEASE) \
+			&& echo "release: created $(TAG) (diff from $(PREV_RELEASE))"; \
 	else \
-		gh release create $(TAG) --title "$(TAG)" --generate-notes; \
-		echo "release: created $(TAG) (first release)"; \
+		$(GH) release create $(TAG) --title "$(TAG)" --generate-notes \
+			&& echo "release: created $(TAG) (first release)"; \
 	fi
 
 srpm: vendor gen-spec

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## Installation
 
-### Ubuntu (PPA)
+### Ubuntu ([PPA](https://launchpad.net/~al-maisan/+archive/ubuntu/gmt-mail))
 
     $ sudo add-apt-repository ppa:al-maisan/gmt-mail
     $ sudo apt update
     $ sudo apt install gmt-mail
 
-### Fedora (COPR)
+### Fedora ([COPR](https://copr.fedorainfracloud.org/coprs/al-maisan/gmt-mail/))
 
     $ sudo dnf copr enable al-maisan/gmt-mail
     $ sudo dnf install gmt-mail
@@ -109,7 +109,7 @@ cc = ["merry@shire.org"]
 
 ## Template variables
 
-Templates support these placeholders (in both subject and body). Custom keys are matched in **uppercase** -- use `%ORG%` not `%org%`.
+Templates support these placeholders (in both subject and body). Custom keys are matched in **uppercase** -- use `%ORG%` not `%org%`. Because keys are case-folded, two data keys that differ only in case (e.g. `url` and `URL`) are rejected as a collision, and a custom key may not reuse a reserved name (`EA`, `FN`, `LN`).
 
 | Placeholder | Value                                    |
 |-------------|------------------------------------------|
@@ -157,7 +157,7 @@ Use `-dry-run` to preview all emails without sending. The output includes Cc and
 | Code | Meaning                          |
 |------|----------------------------------|
 | 0    | Success                          |
-| 1    | Usage error (missing flags)      |
+| 1    | Usage error (missing or invalid flags) |
 | 2    | Config or template file error    |
 | 3    | SMTP connection error            |
 | 4    | One or more emails failed to send|
@@ -189,7 +189,7 @@ Use `-dry-run` to preview all emails without sending. The output includes Cc and
       -version
             print version and exit
 
-Transient send failures are retried automatically (controlled by `-retries` and `-retry-delay`). Progress is shown as `[1/N]` for each message.
+Transient send failures are retried automatically (controlled by `-retries` and `-retry-delay`). If the SMTP connection is dropped mid-batch (e.g. a server idle-timeout or per-connection message cap), it is re-established before the next attempt so the rest of the batch is not lost. Large attachments over slow links may need a higher `-timeout`. Progress is shown as `[1/N]` for each message.
 
 ## Releasing a new version
 
@@ -201,6 +201,8 @@ Cut a release by creating and pushing a signed tag, then publish everywhere:
     $ make publish
 
 `make publish` creates the GitHub release, submits to Fedora COPR, and uploads to Ubuntu PPA, all using the tagged version. To cut it in one shot without tagging first, override: `make publish VERSION=0.7.0` creates and pushes the tag for you.
+
+> **Note:** both package changelogs (the RPM `%changelog` and the Debian `debian/changelog`) are generated from `git log` between **GitHub releases**, so a version appears in them only once a GitHub *release* exists for its tag. `make publish` (and `make release`) create the release *before* building packages, so a full `make publish` yields complete changelogs — but building packages standalone (`make srpm`/`make copr`/`make ppa`) before the release exists will omit that version.
 
 Individual targets are also available:
 

--- a/ppa/build-ppa.sh
+++ b/ppa/build-ppa.sh
@@ -89,8 +89,10 @@ for RELEASE in "${RELEASES[@]}"; do
     cp -a "$SCRIPT_DIR/debian" debian
 
     # Generate changelog from git log between previous tag and current tag
-    # Find previous released tag (not just any tag)
-    PREV_TAG=$(gh release list --limit 100 --json tagName --jq '.[].tagName' 2>/dev/null \
+    # Find previous released tag (not just any tag). Drop any ambient
+    # GITHUB_TOKEN so gh uses the keyring login (a narrow-scoped token would
+    # make this empty and mis-scope the changelog range).
+    PREV_TAG=$(env -u GITHUB_TOKEN gh release list --limit 100 --json tagName --jq '.[].tagName' 2>/dev/null \
         | grep -v "^${TAG}$" | head -1 || echo "")
     TIMESTAMP=$(date -R)
     {

--- a/scripts/gen-rpm-changelog.sh
+++ b/scripts/gen-rpm-changelog.sh
@@ -5,8 +5,10 @@ set -e
 
 MAINTAINER="Muharem Hrnjadovic <muharem@linux.com>"
 
-# List released tags newest first (only tags with actual GitHub releases)
-TAGS=($(gh release list --json tagName --jq '.[].tagName' 2>/dev/null))
+# List released tags newest first (only tags with actual GitHub releases).
+# Drop any ambient GITHUB_TOKEN so gh uses the keyring login; a narrow-scoped
+# token can make this return nothing and silently truncate the changelog.
+TAGS=($(env -u GITHUB_TOKEN gh release list --json tagName --jq '.[].tagName' 2>/dev/null))
 
 if [ ${#TAGS[@]} -eq 0 ]; then
     # Fallback to git tags if gh is unavailable


### PR DESCRIPTION
## Problem
A narrow-scoped `GITHUB_TOKEN` in the environment (the gist-only token) overrides `gh`'s keyring login. As a result:
- `make release` failed to create GitHub releases (`"workflow" scope may be required`), yet **printed `release: created …` anyway** — a trailing `echo` swallowed `gh`'s non-zero exit.
- `gh release list` in both changelog generators ran with the crippled token.

## Fix
- **Makefile**: `GH := env -u GITHUB_TOKEN gh`, used for `PREV_RELEASE` and the `release` target. `gh release create … ; echo` → `… && echo` so a real failure aborts the target instead of reporting success.
- **scripts/gen-rpm-changelog.sh** (RPM `%changelog`) and **ppa/build-ppa.sh** (Debian `debian/changelog`): their `gh release list` calls now drop `GITHUB_TOKEN` too.

## Verified
- `make -n release` shows `env -u GITHUB_TOKEN gh release view/create …`.
- `gen-rpm-changelog.sh` produces correct output even with a bogus `GITHUB_TOKEN` set.
- `bash -n` clean on the script.

After this, `make release` works with a limited `GITHUB_TOKEN` in the environment (no need to `unset` it manually), and a genuine `gh` failure is no longer masked.